### PR TITLE
fix: DeleteWebhook endpoint accepts url only in query parameter

### DIFF
--- a/src/Max.Bot/Api/ISubscriptionsApi.cs
+++ b/src/Max.Bot/Api/ISubscriptionsApi.cs
@@ -35,14 +35,14 @@ public interface ISubscriptionsApi
     /// <summary>
     /// Unsubscribes from updates (deletes the webhook).
     /// </summary>
-    /// <param name="request">The delete webhook request containing the URL to remove.</param>
+    /// <param name="url">URL of the webhook to remove.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the response with success status.</returns>
     /// <exception cref="ArgumentNullException">Thrown when request is null.</exception>
     /// <exception cref="Max.Bot.Exceptions.MaxApiException">Thrown when the API returns an error response.</exception>
     /// <exception cref="Max.Bot.Exceptions.MaxNetworkException">Thrown when a network error occurs.</exception>
     /// <exception cref="Max.Bot.Exceptions.MaxUnauthorizedException">Thrown when authentication fails.</exception>
-    Task<Response> DeleteWebhookAsync(DeleteWebhookRequest request, CancellationToken cancellationToken = default);
+    Task<Response> DeleteWebhookAsync(string url, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets updates using long polling (if bot is not subscribed to webhook).

--- a/src/Max.Bot/Api/SubscriptionsApi.cs
+++ b/src/Max.Bot/Api/SubscriptionsApi.cs
@@ -67,14 +67,19 @@ internal class SubscriptionsApi : BaseApi, ISubscriptionsApi
     }
 
     /// <inheritdoc />
-    public async Task<Response> DeleteWebhookAsync(DeleteWebhookRequest request, CancellationToken cancellationToken = default)
+    public async Task<Response> DeleteWebhookAsync(string url, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(url);
 
-        // DELETE /subscriptions expects JSON body with url parameter
-        var apiRequest = CreateRequest(HttpMethod.Delete, "/subscriptions", request);
+        var queryParams = new Dictionary<string, string?>
+        {
+            { "url", url }
+        };
+
+        var apiRequest = CreateRequest(HttpMethod.Delete, "/subscriptions", null, queryParams);
         return await ExecuteRequestAsync<Response>(apiRequest, cancellationToken).ConfigureAwait(false);
     }
+
 
     /// <inheritdoc />
     public async Task<GetUpdatesResponse> GetUpdatesAsync(GetUpdatesRequest request, CancellationToken cancellationToken = default)

--- a/src/Max.Bot/Max.Bot.csproj
+++ b/src/Max.Bot/Max.Bot.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    
+
     <PackageId>MaxMessenger.Bot</PackageId>
-    <Version>0.4.1-alpha</Version>
+    <Version>0.4.2-alpha</Version>
     <Authors>MaxBotNet Contributors</Authors>
     <Description>C# library for Max Messenger Bot API (.NET 9)</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Max.Bot/MaxClient.cs
+++ b/src/Max.Bot/MaxClient.cs
@@ -224,9 +224,7 @@ public class MaxClient : IMaxBotApi, IUpdatePipeline
     public Task<Response> DeleteWebhookAsync(string url, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(url);
-        return Subscriptions.DeleteWebhookAsync(
-            new DeleteWebhookRequest { Url = url },
-            cancellationToken);
+        return Subscriptions.DeleteWebhookAsync(url, cancellationToken);
     }
 }
 

--- a/tests/Max.Bot.Tests/Unit/Api/SubscriptionsApiTests.cs
+++ b/tests/Max.Bot.Tests/Unit/Api/SubscriptionsApiTests.cs
@@ -172,11 +172,6 @@ public class SubscriptionsApiTests
     public async Task DeleteWebhookAsync_ShouldReturnResponse_WhenRequestSucceeds()
     {
         // Arrange
-        var request = new DeleteWebhookRequest
-        {
-            Url = "https://example.com/webhook"
-        };
-
         var response = new Response
         {
             Success = true,
@@ -188,15 +183,17 @@ public class SubscriptionsApiTests
                 It.Is<MaxApiRequest>(req =>
                     req.Method == HttpMethod.Delete &&
                     req.Endpoint == "/subscriptions" &&
-                    req.Body != null &&
-                    req.Body.GetType() == typeof(DeleteWebhookRequest)),
+                    req.Body == null &&
+                    req.QueryParameters != null &&
+                    req.QueryParameters.ContainsKey("url") &&
+                    req.QueryParameters["url"] == "https://example.com/webhook"),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         var subscriptionsApi = new SubscriptionsApi(_mockHttpClient.Object, _options);
 
         // Act
-        var result = await subscriptionsApi.DeleteWebhookAsync(request);
+        var result = await subscriptionsApi.DeleteWebhookAsync("https://example.com/webhook");
 
         // Assert
         result.Should().NotBeNull();
@@ -205,36 +202,35 @@ public class SubscriptionsApiTests
     }
 
     [Fact]
-    public async Task DeleteWebhookAsync_ShouldSendUrlInBody_WhenRequestProvided()
+    public async Task DeleteWebhookAsync_ShouldSendUrlInQuery_WhenRequestProvided()
     {
         // Arrange
-        var request = new DeleteWebhookRequest
-        {
-            Url = "https://example.com/webhook"
-        };
-
         var response = new Response { Success = true };
 
         _mockHttpClient
             .Setup(x => x.SendAsync<Response>(
                 It.Is<MaxApiRequest>(req =>
                     req.Method == HttpMethod.Delete &&
-                    req.Body != null &&
-                    req.Body.GetType() == typeof(DeleteWebhookRequest)),
+                    req.Body == null &&
+                    req.QueryParameters != null &&
+                    req.QueryParameters.ContainsKey("url") &&
+                    req.QueryParameters["url"] == "https://example.com/webhook"),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         var subscriptionsApi = new SubscriptionsApi(_mockHttpClient.Object, _options);
 
         // Act
-        await subscriptionsApi.DeleteWebhookAsync(request);
+        await subscriptionsApi.DeleteWebhookAsync("https://example.com/webhook");
 
         // Assert
         _mockHttpClient.Verify(x => x.SendAsync<Response>(
             It.Is<MaxApiRequest>(req =>
                 req.Method == HttpMethod.Delete &&
-                req.Body != null &&
-                req.Body.GetType() == typeof(DeleteWebhookRequest)),
+                req.Body == null &&
+                req.QueryParameters != null &&
+                req.QueryParameters.ContainsKey("url") &&
+                req.QueryParameters["url"] == "https://example.com/webhook"),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 


### PR DESCRIPTION
Метод ранее работал с ошибкой
```json
{
    "code": "proto.payload",
    "message": "Missing required parameter: url"
}
```

Поменял отправку url из body в query. Также проверил переписанный метод в нашем приложении, всё работает, всё удаляется
очень ждём новый релиз :3