### PR TITLE
Fix callback message, attachment payload tokens, and video response mapping

### DIFF
--- a/src/Max.Bot/Types/CallbackQuery.cs
+++ b/src/Max.Bot/Types/CallbackQuery.cs
@@ -32,6 +32,7 @@ public class CallbackQuery
     /// Gets or sets the message with the inline button that was pressed.
     /// </summary>
     /// <value>The message with the inline button, or null if not available.</value>
+    [Obsolete("CallbackQuery.Message is not populated by current MAX API webhook contract. Use CallbackQueryUpdate.Message from Update.CallbackQueryUpdate instead.")]
     [JsonIgnore]
     public Message? Message { get; set; }
 

--- a/src/Max.Bot/Types/CallbackQueryUpdate.cs
+++ b/src/Max.Bot/Types/CallbackQueryUpdate.cs
@@ -32,6 +32,15 @@ public class CallbackQueryUpdate
     /// </summary>
     /// <value>The callback query in this update.</value>
     public CallbackQuery CallbackQuery { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the message that contains the callback keyboard.
+    /// </summary>
+    /// <remarks>
+    /// MAX webhook delivers message payload at update level for <c>message_callback</c>,
+    /// so consumers should read message from this property.
+    /// </remarks>
+    public Message? Message { get; set; }
 }
 
 

--- a/src/Max.Bot/Types/Converters/AttachmentJsonConverter.cs
+++ b/src/Max.Bot/Types/Converters/AttachmentJsonConverter.cs
@@ -38,7 +38,7 @@ public class AttachmentJsonConverter : JsonConverter<Attachment>
         // Route by type name — primary and most reliable method
         if (IsType(typeString, AttachmentTypeNames.Image))
         {
-            return JsonSerializer.Deserialize<PhotoAttachment>(root.GetRawText(), options);
+            return DeserializePhotoAttachment(root, options);
         }
 
         if (IsType(typeString, AttachmentTypeNames.InlineKeyboard))
@@ -58,17 +58,17 @@ public class AttachmentJsonConverter : JsonConverter<Attachment>
 
         if (IsType(typeString, AttachmentTypeNames.Video))
         {
-            return DeserializeAttachment<VideoAttachment>(root, "video", options);
+            return DeserializeMediaAttachment<VideoAttachment>(root, "video", options);
         }
 
         if (IsType(typeString, AttachmentTypeNames.Audio))
         {
-            return DeserializeAttachment<AudioAttachment>(root, "audio", options);
+            return DeserializeMediaAttachment<AudioAttachment>(root, "audio", options);
         }
 
         if (IsType(typeString, AttachmentTypeNames.File))
         {
-            return DeserializeAttachment<DocumentAttachment>(root, "document", options);
+            return DeserializeMediaAttachment<DocumentAttachment>(root, "document", options);
         }
 
         // Fallback for unknown types — use DocumentAttachment as it has the most generic fields
@@ -121,6 +121,103 @@ public class AttachmentJsonConverter : JsonConverter<Attachment>
         }
 
         return JsonSerializer.Deserialize<T>(root.GetRawText(), options);
+    }
+
+    private static PhotoAttachment? DeserializePhotoAttachment(JsonElement root, JsonSerializerOptions options)
+    {
+        if (root.TryGetProperty("payload", out var payload) && payload.ValueKind == JsonValueKind.Object)
+        {
+            var attachment = new PhotoAttachment();
+
+            if (payload.TryGetProperty("id", out var idElement) && idElement.ValueKind == JsonValueKind.Number && idElement.TryGetInt64(out var id))
+            {
+                attachment.Id = id;
+            }
+            else if (payload.TryGetProperty("photo_id", out var photoIdElement) && photoIdElement.ValueKind == JsonValueKind.Number && photoIdElement.TryGetInt64(out var photoId))
+            {
+                attachment.Id = photoId;
+            }
+
+            if (payload.TryGetProperty("file_id", out var fileIdElement) && fileIdElement.ValueKind == JsonValueKind.String)
+            {
+                attachment.FileId = fileIdElement.GetString() ?? string.Empty;
+            }
+            else if (payload.TryGetProperty("token", out var tokenElement) && tokenElement.ValueKind == JsonValueKind.String)
+            {
+                attachment.FileId = tokenElement.GetString() ?? string.Empty;
+            }
+
+            if (payload.TryGetProperty("width", out var widthElement) && widthElement.ValueKind == JsonValueKind.Number && widthElement.TryGetInt32(out var width))
+            {
+                attachment.Width = width;
+            }
+
+            if (payload.TryGetProperty("height", out var heightElement) && heightElement.ValueKind == JsonValueKind.Number && heightElement.TryGetInt32(out var height))
+            {
+                attachment.Height = height;
+            }
+
+            if (payload.TryGetProperty("file_size", out var fileSizeElement) && fileSizeElement.ValueKind == JsonValueKind.Number && fileSizeElement.TryGetInt64(out var fileSize))
+            {
+                attachment.FileSize = fileSize;
+            }
+
+            if (payload.TryGetProperty("url", out var urlElement) && urlElement.ValueKind == JsonValueKind.String)
+            {
+                attachment.Url = urlElement.GetString();
+            }
+
+            return attachment;
+        }
+
+        if (root.TryGetProperty("photo", out var photo) && photo.ValueKind == JsonValueKind.Object)
+        {
+            var attachment = JsonSerializer.Deserialize<PhotoAttachment>(photo.GetRawText(), options);
+            if (attachment != null)
+            {
+                attachment.Type = AttachmentTypeNames.Image;
+            }
+
+            return attachment;
+        }
+
+        return JsonSerializer.Deserialize<PhotoAttachment>(root.GetRawText(), options);
+    }
+
+    private static T? DeserializeMediaAttachment<T>(JsonElement root, string payloadPropertyName, JsonSerializerOptions options)
+        where T : Attachment
+    {
+        if (root.TryGetProperty("payload", out var payload) && payload.ValueKind == JsonValueKind.Object)
+        {
+            var attachment = JsonSerializer.Deserialize<T>(payload.GetRawText(), options);
+            if (attachment == null)
+            {
+                return null;
+            }
+
+            switch (attachment)
+            {
+                case AudioAttachment audio when string.IsNullOrWhiteSpace(audio.FileId)
+                    && payload.TryGetProperty("token", out var audioToken)
+                    && audioToken.ValueKind == JsonValueKind.String:
+                    audio.FileId = audioToken.GetString() ?? string.Empty;
+                    break;
+                case VideoAttachment video when string.IsNullOrWhiteSpace(video.FileId)
+                    && payload.TryGetProperty("token", out var videoToken)
+                    && videoToken.ValueKind == JsonValueKind.String:
+                    video.FileId = videoToken.GetString() ?? string.Empty;
+                    break;
+                case DocumentAttachment document when string.IsNullOrWhiteSpace(document.FileId)
+                    && payload.TryGetProperty("token", out var documentToken)
+                    && documentToken.ValueKind == JsonValueKind.String:
+                    document.FileId = documentToken.GetString() ?? string.Empty;
+                    break;
+            }
+
+            return attachment;
+        }
+
+        return DeserializeAttachment<T>(root, payloadPropertyName, options);
     }
 
     private static bool IsType(string? actualType, string expectedType)

--- a/src/Max.Bot/Types/Converters/CallbackQueryJsonConverter.cs
+++ b/src/Max.Bot/Types/Converters/CallbackQueryJsonConverter.cs
@@ -53,12 +53,6 @@ public class CallbackQueryJsonConverter : JsonConverter<CallbackQuery>
             callbackQuery.Timestamp = timestampElement.GetInt64();
         }
 
-        // Read message
-        if (root.TryGetProperty("message", out var messageElement))
-        {
-            callbackQuery.Message = JsonSerializer.Deserialize<Message>(messageElement.GetRawText(), options);
-        }
-
         return callbackQuery;
     }
 
@@ -90,13 +84,6 @@ public class CallbackQueryJsonConverter : JsonConverter<CallbackQuery>
         if (value.Timestamp.HasValue)
         {
             writer.WriteNumber("timestamp", value.Timestamp.Value);
-        }
-
-        // Write message if present
-        if (value.Message != null)
-        {
-            writer.WritePropertyName("message");
-            JsonSerializer.Serialize(writer, value.Message, options);
         }
 
         writer.WriteEndObject();

--- a/src/Max.Bot/Types/Update.cs
+++ b/src/Max.Bot/Types/Update.cs
@@ -147,7 +147,8 @@ public class Update
                 UpdateId = UpdateId,
                 Timestamp = Timestamp,
                 UserLocale = UserLocale,
-                CallbackQuery = Callback
+                CallbackQuery = Callback,
+                Message = Message
             };
         }
     }

--- a/src/Max.Bot/Types/Video.cs
+++ b/src/Max.Bot/Types/Video.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
@@ -8,6 +9,12 @@ namespace Max.Bot.Types;
 /// </summary>
 public class Video
 {
+    /// <summary>
+    /// Gets or sets the media token returned by /videos/{token}.
+    /// </summary>
+    [JsonPropertyName("token")]
+    public string? Token { get; set; }
+
     /// <summary>
     /// Gets or sets the unique identifier of the video.
     /// </summary>
@@ -71,6 +78,30 @@ public class Video
     /// <value>The URL of the video, or null if not available.</value>
     [Url(ErrorMessage = "URL must be a valid URL if provided.")]
     [StringLength(2048, ErrorMessage = "URL must not exceed 2048 characters.")]
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+
+    /// <summary>
+    /// Gets or sets quality-specific video URLs keyed by rendition name (for example, mp4_720).
+    /// </summary>
+    [JsonPropertyName("urls")]
+    public Dictionary<string, string>? Urls { get; set; }
+
+    /// <summary>
+    /// Gets or sets the thumbnail for this video.
+    /// </summary>
+    [JsonPropertyName("thumbnail")]
+    public VideoThumbnail? Thumbnail { get; set; }
+}
+
+/// <summary>
+/// Represents a preview image for a video.
+/// </summary>
+public class VideoThumbnail
+{
+    /// <summary>
+    /// Gets or sets the thumbnail URL.
+    /// </summary>
     [JsonPropertyName("url")]
     public string? Url { get; set; }
 }

--- a/tests/Max.Bot.Tests/Unit/Api/MessagesApiTests.cs
+++ b/tests/Max.Bot.Tests/Unit/Api/MessagesApiTests.cs
@@ -495,6 +495,54 @@ public class MessagesApiTests
         result.Duration.Should().Be(expectedVideo.Duration);
     }
 
+    [Fact]
+    public async Task GetVideoAsync_ShouldMapTokenUrlsAndThumbnail_WhenResponseUsesNewShape()
+    {
+        // Arrange
+        var videoToken = "video-token-123";
+        var responseJson = """
+            {
+              "ok": true,
+              "result": {
+                "token": "f9LHodD0",
+                "width": 720,
+                "height": 1280,
+                "duration": 6633,
+                "urls": {
+                  "mp4_720": "http://vd555.okcdn.ru/video.mp4"
+                },
+                "thumbnail": {
+                  "url": "https://pimg.mycdn.me/thumb.jpg"
+                }
+              }
+            }
+            """;
+
+        _mockHttpClient
+            .Setup(x => x.SendAsyncRaw(
+                It.Is<MaxApiRequest>(req =>
+                    req.Method == HttpMethod.Get &&
+                    req.Endpoint == $"/videos/{videoToken}"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(responseJson);
+
+        var messagesApi = new MessagesApi(_mockHttpClient.Object, _options);
+
+        // Act
+        var result = await messagesApi.GetVideoAsync(videoToken);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Token.Should().Be("f9LHodD0");
+        result.Width.Should().Be(720);
+        result.Height.Should().Be(1280);
+        result.Duration.Should().Be(6633);
+        result.Urls.Should().NotBeNull();
+        result.Urls!["mp4_720"].Should().Be("http://vd555.okcdn.ru/video.mp4");
+        result.Thumbnail.Should().NotBeNull();
+        result.Thumbnail!.Url.Should().Be("https://pimg.mycdn.me/thumb.jpg");
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]

--- a/tests/Max.Bot.Tests/Unit/Types/AttachmentFormatTests.cs
+++ b/tests/Max.Bot.Tests/Unit/Types/AttachmentFormatTests.cs
@@ -57,6 +57,20 @@ public class AttachmentFormatTests
         photo.FileId.Should().Be("abc123");
     }
 
+    [Fact]
+    public void Photo_PayloadFormat_ShouldDeserialize_TokenAndUrl()
+    {
+        var json = """{"type":"image","payload":{"photo_id":14463448907,"token":"token123","url":"https://i.oneme.ru/i?r=abc"}}""";
+
+        var attachment = MaxJsonSerializer.Deserialize<Attachment>(json);
+
+        attachment.Should().BeOfType<PhotoAttachment>();
+        var photo = (PhotoAttachment)attachment;
+        photo.Id.Should().Be(14463448907);
+        photo.FileId.Should().Be("token123");
+        photo.Url.Should().Be("https://i.oneme.ru/i?r=abc");
+    }
+
     // ==================== VIDEO ====================
 
     [Fact]
@@ -110,6 +124,20 @@ public class AttachmentFormatTests
         attachment.Should().BeOfType<AudioAttachment>();
         var audio = (AudioAttachment)attachment;
         audio.Id.Should().Be(789);
+    }
+
+    [Fact]
+    public void Audio_PayloadFormat_ShouldDeserialize_TokenAndUrl()
+    {
+        var json = """{"type":"audio","payload":{"token":"voice-token","url":"https://i.oneme.ru/a?r=abc","duration":13}}""";
+
+        var attachment = MaxJsonSerializer.Deserialize<Attachment>(json);
+
+        attachment.Should().BeOfType<AudioAttachment>();
+        var audio = (AudioAttachment)attachment;
+        audio.FileId.Should().Be("voice-token");
+        audio.Url.Should().Be("https://i.oneme.ru/a?r=abc");
+        audio.Duration.Should().Be(13);
     }
 
     // ==================== DOCUMENT ====================

--- a/tests/Max.Bot.Tests/Unit/Types/CallbackQueryTests.cs
+++ b/tests/Max.Bot.Tests/Unit/Types/CallbackQueryTests.cs
@@ -22,9 +22,7 @@ public class CallbackQueryTests
         callbackQuery.User.Should().NotBeNull();
         callbackQuery.User!.Id.Should().Be(123);
         callbackQuery.User.Username.Should().Be("user123");
-        callbackQuery.Message.Should().NotBeNull();
-        callbackQuery.Message!.Body?.Mid.Should().Be("msg456");
-        callbackQuery.Message.Text.Should().Be("Test message");
+        callbackQuery.Message.Should().BeNull();
         callbackQuery.Payload.Should().Be("payload123");
         callbackQuery.Timestamp.Should().Be(1609459200000);
     }

--- a/tests/Max.Bot.Tests/Unit/Types/UpdateTests.cs
+++ b/tests/Max.Bot.Tests/Unit/Types/UpdateTests.cs
@@ -77,7 +77,7 @@ public class UpdateTests
     public void Deserialize_MessageCallback_ShouldDeserializeCorrectly()
     {
         // Arrange - API format uses "callback" field
-        var json = """{"update_id":2,"update_type":"message_callback","timestamp":1609459200000,"callback":{"callback_id":"cb123","user":{"user_id":123,"username":"user123","is_bot":false},"payload":"button_clicked","timestamp":1609459200000}}""";
+        var json = """{"update_id":2,"update_type":"message_callback","timestamp":1609459200000,"message":{"body":{"mid":"mid.cb.1","text":"Button host"},"timestamp":1609459200000},"callback":{"callback_id":"cb123","user":{"user_id":123,"username":"user123","is_bot":false},"payload":"button_clicked","timestamp":1609459200000}}""";
 
         // Act
         var result = MaxJsonSerializer.Deserialize<Update>(json);
@@ -99,6 +99,8 @@ public class UpdateTests
         result.CallbackQueryUpdate!.UpdateId.Should().Be(2);
         result.CallbackQueryUpdate.CallbackQuery.Should().NotBeNull();
         result.CallbackQueryUpdate.CallbackQuery.CallbackId.Should().Be("cb123");
+        result.CallbackQueryUpdate.Message.Should().NotBeNull();
+        result.CallbackQueryUpdate.Message!.Body!.Mid.Should().Be("mid.cb.1");
     }
 
     #endregion


### PR DESCRIPTION
контракты Max.Bot под актуальный формат MAX Bot API.

Callback / message_callback
Добавлено Message? Message { get; set; } в CallbackQueryUpdate.
В Update.CallbackQueryUpdate теперь пробрасывается Message = Update.Message, чтобы mid исходного сообщения не терялся.
CallbackQuery.Message помечено как [Obsolete] 
Attachments
AttachmentJsonConverter дополнен поддержкой вложенного формата payload для type="image" | "audio" | "video" | "file":
payload.token маппится в FileId
payload.url маппится в Url
для image поддержан payload.photo_id -> PhotoAttachment.Id
Videos
Video расширена актуальными полями ответа: token, urls, thumbnail.url.
MediaService/consumer-подсистема (соответственно тестам) может выбирать URL из urls при отсутствии url.

Добавлены/обновлены юнит-тесты для:
GetVideoAsync нового shape (token, urls, thumbnail)
десериализации attachments из payload-формата (photo_id/token/url, audio.payload.token/url и т.п.)